### PR TITLE
chore(config): set output to 'export' and change distDir to 'dist'

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  distDir: 'dist',
+  output: 'export',
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Set `distDir` to 'dist' to customize Next.js build output directory. Enabled static export by setting `output: 'export'` (Next.js will export static files to the default `out` directory).